### PR TITLE
Use RuntimeDirectory directive to create /var/run/redis

### DIFF
--- a/debian/redis-sentinel.service
+++ b/debian/redis-sentinel.service
@@ -7,6 +7,7 @@ Type=forking
 ExecStart=/usr/bin/redis-sentinel /etc/redis/sentinel.conf
 ExecStop=/usr/bin/redis-cli -p 26379 shutdown
 Restart=always
+RuntimeDirectory=redis
 User=redis
 Group=redis
 

--- a/debian/redis-server.service
+++ b/debian/redis-server.service
@@ -7,6 +7,7 @@ Type=forking
 ExecStart=/usr/bin/redis-server /etc/redis/redis.conf
 ExecStop=/usr/bin/redis-cli shutdown
 Restart=always
+RuntimeDirectory=redis
 User=redis
 Group=redis
 


### PR DESCRIPTION
Redis-server is not able to start under systemd with default redis.conf, due to absence of /var/run/redis
When RuntimeDirectory is specified in *.service file, systemd creates the directory in /var/run and sets correct permissions.

For reference: http://man7.org/linux/man-pages/man5/systemd.exec.5.html