### PR TITLE
Switch from RuntimeDirectory to systemd-tempfiles

### DIFF
--- a/debian/redis-sentinel.service
+++ b/debian/redis-sentinel.service
@@ -4,13 +4,9 @@ After=network.target
 
 [Service]
 Type=forking
-PermissionsStartOnly=true
-ExecStartPre=-/bin/mkdir /var/run/redis
-ExecStartPre=/bin/chown redis:redis /var/run/redis
 ExecStart=/usr/bin/redis-sentinel /etc/redis/sentinel.conf
 ExecStop=/usr/bin/redis-cli -p 26379 shutdown
 Restart=always
-RuntimeDirectory=redis
 User=redis
 Group=redis
 

--- a/debian/redis-server.service
+++ b/debian/redis-server.service
@@ -4,13 +4,9 @@ After=network.target
 
 [Service]
 Type=forking
-PermissionsStartOnly=true
-ExecStartPre=-/bin/mkdir /var/run/redis
-ExecStartPre=/bin/chown redis:redis /var/run/redis
 ExecStart=/usr/bin/redis-server /etc/redis/redis.conf
 ExecStop=/usr/bin/redis-cli shutdown
 Restart=always
-RuntimeDirectory=redis
 User=redis
 Group=redis
 

--- a/debian/redis-server.tmpfile
+++ b/debian/redis-server.tmpfile
@@ -1,0 +1,1 @@
+d /run/redis 2775 redis redis -


### PR DESCRIPTION
A pull request for https://bugs.debian.org/793016

Both redis-server and redis-sentinel use the the same `RuntimeDirectory`
(/run/redis). This is wrong since systemd removes RuntimeDirectory on
service stop. So, stopping redis-server removes redis-sentinel.pid as
well.

Using a systemd-tempfile is a more robust approach. We are also removing
ExecStartPre lines since directory creation is handled in a different
level.