### PR TITLE
Restore Debian-specific support for /etc/redis/redis-{server,sentinel}.{pre,post}-{up,down}.d

### DIFF
--- a/debian/bin/generate-systemd-service-files
+++ b/debian/bin/generate-systemd-service-files
@@ -73,7 +73,6 @@ Documentation=http://redis.io/documentation, man:${BINARY}(1)
 [Service]
 Type=forking
 ExecStart=/usr/bin/${BINARY} /etc/redis/${NAMESPACED}.conf
-ExecStop=/bin/kill -s TERM \$MAINPID
 PIDFile=/var/run/${NAMESPACED}/${BINARY}.pid
 TimeoutStopSec=0
 Restart=always
@@ -81,6 +80,12 @@ User=redis
 Group=redis
 RuntimeDirectory=${NAMESPACED}
 RuntimeDirectoryMode=2755
+
+ExecStartPre=-/bin/run-parts --verbose /etc/redis/${BINARY}.pre-up.d
+ExecStartPost=-/bin/run-parts --verbose /etc/redis/${BINARY}.post-up.d
+ExecStop=-/bin/run-parts --verbose /etc/redis/${BINARY}.pre-down.d
+ExecStop=/bin/kill -s TERM \$MAINPID
+ExecStopPost=-/bin/run-parts --verbose /etc/redis/${BINARY}.post-down.d
 
 UMask=007
 PrivateTmp=yes

--- a/debian/redis-sentinel.init
+++ b/debian/redis-sentinel.init
@@ -38,6 +38,13 @@ then
 	exit 1
 fi
 
+Run_parts () {
+	if [ -d /etc/redis/${NAME}.${1}.d ]
+	then
+		su redis -s /bin/sh -c "run-parts --exit-on-error /etc/redis/${NAME}.${1}.d"
+	fi
+}
+
 case "$1" in
   start)
 	echo -n "Starting $DESC: "
@@ -51,8 +58,11 @@ case "$1" in
 		ulimit -n $ULIMIT || true
 	fi
 
+	Run_parts pre-up
+
 	if start-stop-daemon --start --quiet --oknodo --umask 007 --pidfile $PIDFILE --chuid redis:redis --exec $DAEMON -- $DAEMON_ARGS
 	then
+		Run_parts post-up
 		echo "$NAME."
 	else
 		echo "failed"
@@ -61,8 +71,11 @@ case "$1" in
   stop)
 	echo -n "Stopping $DESC: "
 
+	Run_parts pre-down
+
 	if start-stop-daemon --stop --retry forever/TERM/1 --quiet --oknodo --pidfile $PIDFILE --exec $DAEMON
 	then
+		Run_parts post-down
 		echo "$NAME."
 	else
 		echo "failed"

--- a/debian/redis-sentinel.maintscript
+++ b/debian/redis-sentinel.maintscript
@@ -1,4 +1,0 @@
-rm_conffile /etc/redis/redis-sentinel.pre-up.d/00_example 4:4.0.2-3~
-rm_conffile /etc/redis/redis-sentinel.pre-down.d/00_example 4:4.0.2-3~
-rm_conffile /etc/redis/redis-sentinel.post-up.d/00_example 4:4.0.2-3~
-rm_conffile /etc/redis/redis-sentinel.post-down.d/00_example 4:4.0.2-3~

--- a/debian/redis-sentinel.postinst
+++ b/debian/redis-sentinel.postinst
@@ -15,10 +15,4 @@ fi
 
 #DEBHELPER#
 
-case "${1}" in
-	configure)
-		find /etc/redis -maxdepth 1 -type d -name 'redis-sentinel.*.d' -empty -delete
-		;;
-esac
-
 exit 0

--- a/debian/redis-server.init
+++ b/debian/redis-server.init
@@ -38,6 +38,13 @@ then
 	exit 1
 fi
 
+Run_parts () {
+	if [ -d /etc/redis/${NAME}.${1}.d ]
+	then
+		su redis -s /bin/sh -c "run-parts --exit-on-error /etc/redis/${NAME}.${1}.d"
+	fi
+}
+
 case "$1" in
   start)
 	echo -n "Starting $DESC: "
@@ -51,8 +58,11 @@ case "$1" in
 		ulimit -n $ULIMIT || true
 	fi
 
+	Run_parts pre-up
+
 	if start-stop-daemon --start --quiet --oknodo --umask 007 --pidfile $PIDFILE --chuid redis:redis --exec $DAEMON -- $DAEMON_ARGS
 	then
+		Run_parts post-up
 		echo "$NAME."
 	else
 		echo "failed"
@@ -61,8 +71,11 @@ case "$1" in
   stop)
 	echo -n "Stopping $DESC: "
 
+	Run_parts pre-down
+
 	if start-stop-daemon --stop --retry forever/TERM/1 --quiet --oknodo --pidfile $PIDFILE --exec $DAEMON
 	then
+		Run_parts post-down
 		echo "$NAME."
 	else
 		echo "failed"

--- a/debian/redis-server.maintscript
+++ b/debian/redis-server.maintscript
@@ -1,5 +1,0 @@
-rm_conffile /etc/redis/redis-server.pre-up.d/00_example 4:4.0.2-3~
-rm_conffile /etc/redis/redis-server.pre-down.d/00_example 4:4.0.2-3~
-rm_conffile /etc/redis/redis-server.post-up.d/00_example 4:4.0.2-3~
-rm_conffile /etc/redis/redis-server.post-down.d/00_example 4:4.0.2-3~
-

--- a/debian/redis-server.postinst
+++ b/debian/redis-server.postinst
@@ -43,10 +43,4 @@ esac
 
 #DEBHELPER#
 
-case "${1}" in
-	configure)
-		find /etc/redis -maxdepth 1 -type d -name 'redis-server.*.d' -empty -delete
-		;;
-esac
-
 exit 0

--- a/debian/rules
+++ b/debian/rules
@@ -20,6 +20,7 @@ endif
 	dh $@ --with systemd
 
 override_dh_auto_install:
+	debian/bin/generate-parts
 	debian/bin/generate-systemd-service-files
 
 override_dh_auto_build:


### PR DESCRIPTION
This reverts commit 6a9e4d0142b45195a0d55945bbc558df4c48707b.

Devuan downstream needs this run-parts functionality for service state change hooks.
Please consider allowing it to remain? :bowing_man: 